### PR TITLE
Add 'load' & chart options

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,8 +3,10 @@ module Main where
 
 import Control.Concurrent (threadDelay)
 import Control.Monad      (forever, forM_)
+import Data.Default
 
 import C3
+import C3.Chart.Gauge
 
 main :: IO ()
 main = do
@@ -51,4 +53,4 @@ pieData2 :: Datum
 pieData2 = Rows ["US", "Them", "something", "Gary Busey"] [[10,5,15,70]]
 
 gaugeOpts :: GaugeOpts
-gaugeOpts = GaugeOpt 0 100 "PERCENT" 138
+gaugeOpts = def { gaugeWidth = Just 138 }

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,30 +11,24 @@ main = do
   js_createChartContainer "chart"
   js_createChartContainer "gauge-chart"
   chart <- generate opts
-  gaugeChart <- generate gaugeChart
-  loadData gaugeChart $ gaugeColumn "whatever" 80.9 gaugeOpts
+  gaugeChart <- generate gaugeChartOpt
   threadDelay (2 * second)
-  _newChart <- loadData gaugeChart $ gaugeColumn "whatever" 25.9  gaugeOpts
+  _ <- loadData gaugeChart $ [ Column "whatever" [80.9] ]
   forever $ do
     forM_ [Area, Pie, Donut, (Gauge gaugeOpts), Step] $ \typ -> do
       threadDelay (2 * second)
       transform chart typ
   where
-    opts = ChartOptions "#chart" chartDatas Nothing
     second = 1000000
-    gaugeChart = ChartOptions "#gauge-chart" gaugeData $
-             Just $ ChartSizeOptions 280
+    opts = ChartOptions "#chart" chartDatas Nothing
+    gaugeChartOpt = ChartOptions "#gauge-chart" gaugeData $
+             Just $ ChartSizeOptions 180
+    chartDatas = ChartData Bar
+                  [ Column "data1" [30, 200, 100, 400, 150, 250]
+                  , Column "data2" [50, 20, 10, 40, 15, 25]
+                  ]
+    gaugeData = ChartData (Gauge gaugeOpts)
+                  [ Column "whatever" [25.3]
+                  ]
 
-
-chartDatas = ChartData Bar
-               [ Column "data1" [30, 200, 100, 400, 150, 250]
-               , Column "data2" [50, 20, 10, 40, 15, 25]
-               ]
-gaugeData = ChartData (Gauge gaugeOpts)
-               [ Column "whatever" [25.3]
-               ]
-
-gaugeOpts = GaugeOpt 0 100 "PERCENT" 138
-
-gaugeColumn title val opts =  ChartData (Gauge opts)
-                          [ Column title [val] ]
+    gaugeOpts = GaugeOpt 0 100 "PERCENT" 138

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,9 +15,9 @@ main = do
   gaugeChart <- generate gaugeChartOpt
   pieChart <- generate pieChartOpt
   threadDelay (2 * second)
-  _ <- loadData gaugeChart $ Columns [ Column "whatever" [80.9] ]
+  _ <- load gaugeChart $ Columns [ Column "whatever" [80.9] ]
   threadDelay (2 * second)
-  _ <- loadData pieChart pieData2
+  _ <- load pieChart pieData2
   forever $ do
     forM_ [Area, Pie, Donut, Step] $ \typ -> do
       threadDelay (2 * second)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,7 +48,7 @@ largerChart :: Maybe ChartSizeOptions
 largerChart = Just $ def { chartSizeOptionsHeight = Just 250 }
 
 pieData :: Datum
-pieData = Rows ["US", "Them"] [[60],[40]]
+pieData = Columns [ Column "US" [60], Column "Them" [40]]
 
 pieData2 :: Datum
 pieData2 = fromKeyValue $ zip ["US", "Them", "something", "Gary Busey"] [10,5,4,8]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,15 +9,32 @@ import C3
 main :: IO ()
 main = do
   js_createChartContainer "chart"
+  js_createChartContainer "gauge-chart"
   chart <- generate opts
+  gaugeChart <- generate gaugeChart
+  loadData gaugeChart $ gaugeColumn "whatever" 80.9 gaugeOpts
+  threadDelay (2 * second)
+  _newChart <- loadData gaugeChart $ gaugeColumn "whatever" 25.9  gaugeOpts
   forever $ do
-    forM_ [Area, Pie, Donut, Gauge, Step] $ \typ -> do
+    forM_ [Area, Pie, Donut, (Gauge gaugeOpts), Step] $ \typ -> do
       threadDelay (2 * second)
       transform chart typ
   where
-    opts = ChartOptions "#chart" $
-             ChartData Bar $
+    opts = ChartOptions "#chart" chartDatas Nothing
+    second = 1000000
+    gaugeChart = ChartOptions "#gauge-chart" gaugeData $
+             Just $ ChartSizeOptions 280
+
+
+chartDatas = ChartData Bar
                [ Column "data1" [30, 200, 100, 400, 150, 250]
                , Column "data2" [50, 20, 10, 40, 15, 25]
                ]
-    second = 1000000
+gaugeData = ChartData (Gauge gaugeOpts)
+               [ Column "whatever" [25.3]
+               ]
+
+gaugeOpts = GaugeOpt 0 100 "PERCENT" 138
+
+gaugeColumn title val opts =  ChartData (Gauge opts)
+                          [ Column title [val] ]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,16 +10,16 @@ import C3.Chart.Gauge
 
 main :: IO ()
 main = do
-  js_createChartContainer "chart"
   js_createChartContainer "gauge-chart"
   js_createChartContainer "pie-chart"
-  chart <- generate opts
+  js_createChartContainer "chart"
   gaugeChart <- generate gaugeChartOpt
   pieChart <- generate pieChartOpt
   threadDelay (2 * second)
   _ <- load gaugeChart $ Columns [ Column "whatever" [80.9] ]
   threadDelay (2 * second)
   _ <- load pieChart pieData2
+  chart <- generate opts
   forever $ do
     forM_ [Area, Pie, Donut, Step] $ \typ -> do
       threadDelay (2 * second)
@@ -44,13 +44,13 @@ mainColumns = Columns
   ]
 
 largerChart :: Maybe ChartSizeOptions
-largerChart = Just $ ChartSizeOptions 280
+largerChart = Just $ ChartSizeOptions 250
 
 pieData :: Datum
-pieData = Rows ["US", "Them"] [[60,40]]
+pieData = Rows ["US", "Them"] [[60],[40]]
 
 pieData2 :: Datum
-pieData2 = Rows ["US", "Them", "something", "Gary Busey"] [[10,5,15,70]]
+pieData2 = Rows ["US", "Them", "something", "Gary Busey"] [[10],[5],[4],[8]]
 
 gaugeOpts :: GaugeOpts
-gaugeOpts = def { gaugeWidth = Just 138 }
+gaugeOpts = def { gaugeWidth = Just 25 }

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,25 +10,45 @@ main :: IO ()
 main = do
   js_createChartContainer "chart"
   js_createChartContainer "gauge-chart"
+  js_createChartContainer "pie-chart"
   chart <- generate opts
   gaugeChart <- generate gaugeChartOpt
+  pieChart <- generate pieChartOpt
   threadDelay (2 * second)
-  _ <- loadData gaugeChart $ [ Column "whatever" [80.9] ]
+  _ <- loadData gaugeChart $ Columns [ Column "whatever" [80.9] ]
+  threadDelay (2 * second)
+  _ <- loadData pieChart pieData2
   forever $ do
-    forM_ [Area, Pie, Donut, (Gauge gaugeOpts), Step] $ \typ -> do
+    forM_ [Area, Pie, Donut, Step] $ \typ -> do
       threadDelay (2 * second)
       transform chart typ
   where
     second = 1000000
     opts = ChartOptions "#chart" chartDatas Nothing
-    gaugeChartOpt = ChartOptions "#gauge-chart" gaugeData $
-             Just $ ChartSizeOptions 180
-    chartDatas = ChartData Bar
-                  [ Column "data1" [30, 200, 100, 400, 150, 250]
-                  , Column "data2" [50, 20, 10, 40, 15, 25]
-                  ]
-    gaugeData = ChartData (Gauge gaugeOpts)
-                  [ Column "whatever" [25.3]
-                  ]
+    chartDatas = ChartData Bar mainColumns
+    gaugeChartOpt = ChartOptions "#gauge-chart" gaugeData largerChart
+    gaugeData = ChartData (Gauge gaugeOpts) gaugeColumns1
 
-    gaugeOpts = GaugeOpt 0 100 "PERCENT" 138
+    pieChartOpt = ChartOptions "#pie-chart" (ChartData Pie pieData) Nothing
+
+gaugeColumns1 :: Datum
+gaugeColumns1 = Columns
+  [ Column "whatever" [25.3]]
+
+mainColumns :: Datum
+mainColumns = Columns
+  [ Column "data1" [30, 200, 100, 400, 150, 250]
+  , Column "data2" [50, 20, 10, 40, 15, 25]
+  ]
+
+largerChart :: Maybe ChartSizeOptions
+largerChart = Just $ ChartSizeOptions 280
+
+pieData :: Datum
+pieData = Rows ["US", "Them"] [[60,40]]
+
+pieData2 :: Datum
+pieData2 = Rows ["US", "Them", "something", "Gary Busey"] [[10,5,15,70]]
+
+gaugeOpts :: GaugeOpts
+gaugeOpts = GaugeOpt 0 100 "PERCENT" 138

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,7 @@ import Data.Default
 
 import C3
 import C3.Chart.Gauge
+import C3.Chart
 
 main :: IO ()
 main = do
@@ -44,13 +45,13 @@ mainColumns = Columns
   ]
 
 largerChart :: Maybe ChartSizeOptions
-largerChart = Just $ ChartSizeOptions 250
+largerChart = Just $ def { chartSizeOptionsHeight = Just 250 }
 
 pieData :: Datum
 pieData = Rows ["US", "Them"] [[60],[40]]
 
 pieData2 :: Datum
-pieData2 = Rows ["US", "Them", "something", "Gary Busey"] [[10],[5],[4],[8]]
+pieData2 = fromKeyValue $ zip ["US", "Them", "something", "Gary Busey"] [10,5,4,8]
 
 gaugeOpts :: GaugeOpts
 gaugeOpts = def { gaugeWidth = Just 25 }

--- a/ghcjs-c3.cabal
+++ b/ghcjs-c3.cabal
@@ -17,6 +17,7 @@ library
   exposed-modules:     C3
                      , C3.Foreign
                      , C3.Types
+                     , C3.Chart
                      , C3.Chart.Gauge
   ghc-options:         -Wall
   build-depends:       aeson

--- a/ghcjs-c3.cabal
+++ b/ghcjs-c3.cabal
@@ -17,10 +17,12 @@ library
   exposed-modules:     C3
                      , C3.Foreign
                      , C3.Types
+                     , C3.Chart.Gauge
   ghc-options:         -Wall
   build-depends:       aeson
                      , base >= 4.7 && < 5
                      , ghcjs-base
+                     , data-default
                      , text
                      , time
                      , vector
@@ -32,6 +34,7 @@ executable ghcjs-c3-exe
   ghc-options:         -Wall
   build-depends:       base
                      , ghcjs-c3
+                     , data-default
   default-language:    Haskell2010
 
 test-suite ghcjs-c3-test

--- a/src/C3.hs
+++ b/src/C3.hs
@@ -2,7 +2,7 @@ module C3
   ( module X
   , generate
   , transform
-  , loadData
+  , load
   ) where
 
 import GHCJS.Marshal (toJSVal_aeson)
@@ -15,8 +15,8 @@ generate :: ChartOptions -> IO Chart
 generate = (=<<) js_c3_generate . toJSVal_aeson
 
 -- | Load new data into an existing chart
-loadData :: Chart -> Datum -> IO Chart
-loadData chart datum = toJSVal_aeson datum >>= js_c3_load chart
+load :: Chart -> Datum -> IO Chart
+load chart datum = toJSVal_aeson datum >>= js_c3_load chart
 
 -- | Unload a specific data set from an existing chart
 -- unloadData :: Chart -> DataIndex -> IO Chart

--- a/src/C3.hs
+++ b/src/C3.hs
@@ -14,8 +14,13 @@ import C3.Types   as X
 generate :: ChartOptions -> IO Chart
 generate = (=<<) js_c3_generate . toJSVal_aeson
 
-loadData :: Chart -> ChartData -> IO Chart
-loadData chart column_data = toJSVal_aeson column_data >>= js_c3_load chart
+-- | Load new data into an existing chart
+loadData :: Chart -> [Column]-> IO Chart
+loadData chart column_data = toJSVal_aeson (Columns column_data) >>= js_c3_load chart
+
+-- | Unload a specific data set from an existing chart
+-- unloadData :: Chart -> DataIndex -> IO Chart
+-- unloadData chart index = toJSVal_aeson index >>= js_c3_unload chart
 
 -- | Alter the chart type of a previously rendered chart.
 transform :: Chart -> ChartType -> IO ()

--- a/src/C3.hs
+++ b/src/C3.hs
@@ -2,6 +2,7 @@ module C3
   ( module X
   , generate
   , transform
+  , loadData
   ) where
 
 import GHCJS.Marshal (toJSVal_aeson)
@@ -12,6 +13,9 @@ import C3.Types   as X
 -- | Generate a chart using C3.
 generate :: ChartOptions -> IO Chart
 generate = (=<<) js_c3_generate . toJSVal_aeson
+
+loadData :: Chart -> ChartData -> IO Chart
+loadData chart column_data = toJSVal_aeson column_data >>= js_c3_load chart
 
 -- | Alter the chart type of a previously rendered chart.
 transform :: Chart -> ChartType -> IO ()

--- a/src/C3.hs
+++ b/src/C3.hs
@@ -15,8 +15,8 @@ generate :: ChartOptions -> IO Chart
 generate = (=<<) js_c3_generate . toJSVal_aeson
 
 -- | Load new data into an existing chart
-loadData :: Chart -> [Column]-> IO Chart
-loadData chart column_data = toJSVal_aeson (Columns column_data) >>= js_c3_load chart
+loadData :: Chart -> Datum -> IO Chart
+loadData chart datum = toJSVal_aeson datum >>= js_c3_load chart
 
 -- | Unload a specific data set from an existing chart
 -- unloadData :: Chart -> DataIndex -> IO Chart

--- a/src/C3/Chart.hs
+++ b/src/C3/Chart.hs
@@ -1,0 +1,10 @@
+module C3.Chart where
+
+import Data.Text (Text)
+import C3.Types
+
+fromKeyValue :: [(Text, Double)] -> Datum
+fromKeyValue kv = Rows headers values
+  where
+    values = map (\a -> [snd a]) kv
+    headers = map fst kv

--- a/src/C3/Chart.hs
+++ b/src/C3/Chart.hs
@@ -4,7 +4,4 @@ import Data.Text (Text)
 import C3.Types
 
 fromKeyValue :: [(Text, Double)] -> Datum
-fromKeyValue kv = Rows headers values
-  where
-    values = map (\a -> [snd a]) kv
-    headers = map fst kv
+fromKeyValue = Columns . map (\(k,v) -> Column k [v])

--- a/src/C3/Chart/Chart.hs
+++ b/src/C3/Chart/Chart.hs
@@ -1,1 +1,0 @@
-module C3.Chart where

--- a/src/C3/Chart/Chart.hs
+++ b/src/C3/Chart/Chart.hs
@@ -1,0 +1,1 @@
+module C3.Chart where

--- a/src/C3/Chart/Gauge.hs
+++ b/src/C3/Chart/Gauge.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+module C3.Chart.Gauge where
+
+import Data.Aeson
+import Data.Default
+import Data.Text
+
+data GaugeOpts = GaugeOpts
+  { gaugeExpand :: Bool
+  , gaugeMin    :: Int
+  , gaugeMax    :: Int
+  , gaugeUnits  :: Maybe Text
+  , gaugeWidth  :: Maybe Int
+  } deriving (Show)
+
+instance Default GaugeOpts where
+  def = GaugeOpts True 0 100 Nothing Nothing
+
+instance ToJSON GaugeOpts where
+  toJSON GaugeOpts{..} = object [
+    "expand" .= gaugeExpand,
+    "min"    .= gaugeMin,
+    "max"    .= gaugeMax,
+    "units"  .= gaugeUnits,
+    "width"  .= maybe (String "auto") (Number . fromIntegral) gaugeWidth ]

--- a/src/C3/Foreign.hs
+++ b/src/C3/Foreign.hs
@@ -14,6 +14,9 @@ foreign import javascript unsafe "$1.transform($2);"
 foreign import javascript unsafe "$1.load($2);"
   js_c3_load :: Chart -> JSVal -> IO Chart
 
+foreign import javascript unsafe "$1.unload($2);"
+  js_c3_unload :: Chart -> JSVal -> IO Chart
+
 foreign import javascript unsafe
   "function createChartContainer(bindto) {\
   \  var e = document.createElement('div');\

--- a/src/C3/Foreign.hs
+++ b/src/C3/Foreign.hs
@@ -11,6 +11,9 @@ foreign import javascript unsafe "$r = c3.generate($1);"
 foreign import javascript unsafe "$1.transform($2);"
   js_c3_transform :: Chart -> JSVal -> IO ()
 
+foreign import javascript unsafe "$1.load($2);"
+  js_c3_load :: Chart -> JSVal -> IO Chart
+
 foreign import javascript unsafe
   "function createChartContainer(bindto) {\
   \  var e = document.createElement('div');\

--- a/src/C3/Types.hs
+++ b/src/C3/Types.hs
@@ -4,6 +4,7 @@ module C3.Types where
 
 import           Data.Aeson
 import           Data.Text   (Text)
+import           Data.Text (pack)
 import           GHCJS.Types (JSVal)
 import           Data.Vector (fromList)
 
@@ -16,6 +17,12 @@ data ChartOptions = ChartOptions
     bindTo    :: Text
     -- | The data sourcing the chart.
   , chartData :: ChartData
+  , chartSizeOptions :: Maybe ChartSizeOptions
+  }
+
+data ChartSizeOptions
+  = ChartSizeOptions
+  { _chart_size_height :: Int
   }
 
 -- | The data source for our chart.
@@ -25,6 +32,14 @@ data ChartData = ChartData
     -- | The columns of data.
   , chartColumns :: [Column]
   }
+
+data GaugeOpts
+  = GaugeOpt
+  { _gauge_min :: Int
+  , _gauge_max :: Int
+  , _gauge_units :: Text
+  , _gauge_width :: Int
+  } deriving Show
 
 -- | A column of data to source our chart.
 data Column = Column
@@ -46,12 +61,19 @@ data ChartType
   | Scatter
   | Pie
   | Donut
-  | Gauge
+  | Gauge GaugeOpts
+  deriving Show
 
 instance ToJSON ChartOptions where
   toJSON ChartOptions{..} = object [
     "bindto" .= bindTo,
-    "data"   .= chartData ]
+    "data"   .= chartData,
+    "size"   .= chartSizeOptions,
+    (pack $ show (chartType chartData)) .= chartType chartData]
+
+instance ToJSON ChartSizeOptions where
+  toJSON ChartSizeOptions{..} = object [
+    "height" .= _chart_size_height]
 
 instance ToJSON ChartData where
   toJSON ChartData{..} = object [
@@ -59,8 +81,16 @@ instance ToJSON ChartData where
     "columns" .= chartColumns ]
 
 instance ToJSON Column where
-  toJSON Column{..} = 
+  toJSON Column{..} =
     Array (fromList (String columnName : map toJSON columnValues))
+
+instance ToJSON GaugeOpts where
+  toJSON GaugeOpt{..} = object [
+      "min"   .= _gauge_min
+    , "max"   .= _gauge_max
+    , "units" .= _gauge_units
+    , "width" .= _gauge_width
+    ]
 
 instance ToJSON ChartType where
   toJSON Line       = String "line"
@@ -73,4 +103,4 @@ instance ToJSON ChartType where
   toJSON Scatter    = String "scatter"
   toJSON Pie        = String "pie"
   toJSON Donut      = String "donut"
-  toJSON Gauge      = String "gauge"
+  toJSON (Gauge _)  = String "gauge"

--- a/src/C3/Types.hs
+++ b/src/C3/Types.hs
@@ -5,7 +5,7 @@ module C3.Types where
 
 import Data.Aeson
 import Data.Default
-import Data.Maybe (catMaybes )
+import Data.Maybe (catMaybes)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Vector (fromList)
@@ -52,13 +52,11 @@ data ChartData = ChartData
 
 data Datum
   = Columns [Column]
-  | Rows [Text] [[Double]]
-  -- | Url Text
   -- | Json Text
+  -- | Row [Text] [[Double]]
+  -- | Url Text
 
 instance ToJSON Datum where
-  toJSON (Rows rowHeaders rowValues) = object [
-    "rows" .= [map toJSON rowHeaders, map toJSON rowValues] ]
   toJSON (Columns columns) = object [ "columns" .= map toJSON columns ]
 
 instance ToJSON Column where
@@ -111,7 +109,6 @@ instance ToJSON ChartData where
       base = [ "type"    .= toJSON chartType ]
       conjoined =  base ++ datum
       datum = case chartDatum of
-        Rows h r -> ["rows" .= [map toJSON h, map toJSON r] ]
         Columns c -> ["columns" .= toJSON c]
 
 instance ToJSON ChartType where

--- a/src/C3/Types.hs
+++ b/src/C3/Types.hs
@@ -119,4 +119,4 @@ instance ToJSON ChartType where
   toJSON Scatter    = String "scatter"
   toJSON Pie        = String "pie"
   toJSON Donut      = String "donut"
-  toJSON (Gauge g)  = object [ "gauge" .= toJSON g]
+  toJSON (Gauge _)  = String "gauge"

--- a/src/C3/Types.hs
+++ b/src/C3/Types.hs
@@ -3,12 +3,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module C3.Types where
 
-import           Data.Aeson
-import           Data.Monoid ((<>))
-import           Data.Text   (Text)
-import           Data.Text (pack, toLower)
-import           GHCJS.Types (JSVal)
-import           Data.Vector (fromList)
+import Data.Aeson
+import Data.Default
+import Data.Maybe (catMaybes )
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Data.Vector (fromList)
+import GHCJS.Types (JSVal)
 
 import C3.Chart.Gauge
 
@@ -32,9 +33,13 @@ data ChartOptions = ChartOptions
   , chartSizeOptions :: Maybe ChartSizeOptions
   }
 
+instance Default ChartSizeOptions where
+  def = ChartSizeOptions Nothing Nothing
+
 data ChartSizeOptions
   = ChartSizeOptions
-  { chartSizeOptionsHeight :: Int
+  { chartSizeOptionsHeight :: Maybe Int
+  , chartSizeOptionsWidth :: Maybe Int
   }
 
 -- | The data source for our chart.
@@ -96,8 +101,9 @@ instance ToJSON ChartOptions where
        Just sizeOpts -> [ "size" .= toJSON sizeOpts ]
 
 instance ToJSON ChartSizeOptions where
-  toJSON ChartSizeOptions{..} = object [
-    "height" .= chartSizeOptionsHeight ]
+  toJSON ChartSizeOptions{..} = object $ catMaybes [
+      "height" .=? chartSizeOptionsHeight
+    , "width"  .=? chartSizeOptionsWidth ]
 
 instance ToJSON ChartData where
   toJSON ChartData{..} = object conjoined


### PR DESCRIPTION
I really like this interface for charts! This Pull Request is sort of meant as an RFP or just a way of discussing what direction the library could go.

The style and choices I made implementing these are dubious at best, but I'd like to figure out how best to move this forward.

What's implemented here:

- Gauge charts get a GaugeOpts to put config options in. (The rest of the charts could follow this example with their own specifics)
- `load :: Chart -> Datum -> Chart` for loading in new columns
- unload _could_ be added.. maybe the type is Chart -> Text -> Chart where the 2nd arg describes the data index to unload? I'm not sure of C3's usage of unload beyond the examples I've seen.

Anyway, thanks for starting this library